### PR TITLE
Fold expressions recursively

### DIFF
--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -12,6 +12,12 @@ fn test_simple_wrap() {
 }
 
 #[test]
+#[overflow(wrap)]
+fn test_double_wrap() {
+    1u8 - 2 + 2;
+}
+
+#[test]
 #[overflow(panic)]
 #[should_panic]
 fn test_simple_panic_sub() {


### PR DESCRIPTION
This fixes #4 by changing the `noop_fold_expr(..)` to `o.fold_expr(_)` for both receiver & args.