### PR TITLE
Rustup + version bump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "overflower"
-version = "0.3.3"
+version = "0.4.0"
 authors = ["Andre Bogus <bogusandre@gmail.com>"]
 license = "Apache-2.0"
 repository = "https://github.com/llogiq/overflower"

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ To use it, you need the following in your Cargo.toml:
 
 ```toml
 [dependencies]
-overflower = "0.3.3"
+overflower = "0.4.0"
 overflower_support = "0.1.5"
 ```
 
-You may also make it an optional dependency (`overflower = { version = "0.1.1", 
+You may also make it an optional dependency (`overflower = { version = "0.4.0", 
 optional = true }`).
 
 Next, in your crate root, you need to add:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,16 +155,10 @@ fn tag_method(o: &mut Overflower, name: &str, args: Vec<P<Expr>>, outer: Span, o
     let crate_name = o.cx.ident_of("overflower_support");
     let trait_name = o.cx.ident_of(&get_trait_name(o.mode, name));
     let fn_name = o.cx.ident_of(&format!("{}_{}", name, o.mode));
-    let pspan = marked(o, op);
-    let path = o.cx.path(pspan, vec![crate_name, trait_name, fn_name]);
+    let path = o.cx.path(op, vec![crate_name, trait_name, fn_name]);
     let epath = o.cx.expr_path(path);
     let args_expanded = o.fold_exprs(args);
-    let span = marked(o, outer);
-    o.cx.expr_call(span, epath, args_expanded)
-}
-
-fn marked(o: &mut Overflower, span: Span) -> Span {
-    Span { expn_id: o.cx.backtrace(), ..span }
+    o.cx.expr_call(outer, epath, args_expanded)
 }
 
 fn is_abs(p: &Path) -> bool {


### PR DESCRIPTION
This is just an intermittent solution until I get to use the new procedural-attr-macro interface (but that'll need some more rewriting). It doesn't do the right thing with regards to spans, but should otherwise work OK.