### PR TITLE
Rewrite as #[proc_macro_attribute]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,9 @@ categories = ["development-tools"]
 travis-ci = { repository = "llogiq/overflower" }
 
 [lib]
-crate-type = [ "dylib" ]
-plugin = true
+proc_macro = true
 
 [dependencies]
 overflower_support = { version = "0.1.5", path = "support" }
+syn = { version = "0.15.18", features = ["extra-traits", "full", "fold", "parsing", "proc-macro"] }
+quote = "0.6.9"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,264 +1,244 @@
-#![feature(plugin_registrar, rustc_private)]
+extern crate proc_macro;
+extern crate syn;
+extern crate quote;
 
-extern crate smallvec;
-extern crate rustc_plugin;
-extern crate syntax;
+use self::proc_macro::TokenStream;
+use quote::quote;
+use syn::fold::{self, Fold};
+use syn::parse::{Parse, ParseStream, Result};
+use syn::*;
 
-use std::fmt::{self, Display, Formatter};
-
-use rustc_plugin::registry::Registry;
-use smallvec::SmallVec;
-use syntax::source_map::{DUMMY_SP, Span, Spanned};
-use syntax::ast::{BinOpKind, Block, Expr, ExprKind, Item, ItemKind, Lit,
-                  LitKind, Mac, MetaItem, MetaItemKind, NestedMetaItemKind,
-                  Path, PathSegment, Stmt, StmtKind, UnOp};
-use syntax::ext::base::{Annotatable, ExtCtxt, SyntaxExtension};
-use syntax::ext::build::AstBuilder;
-use syntax::fold::{self, Folder};
-use syntax::symbol::Symbol;
-use syntax::ptr::P;
-
-#[derive(PartialEq, Eq, Clone, Copy)]
-enum Mode {
+#[derive(Copy, Clone)]
+enum Overflower {
     Wrap,
     Panic,
     Saturate,
-    DontCare
+    Default,
 }
 
-impl Display for Mode {
-    fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
-        fmt.write_str(match *self {
-            Mode::Wrap => "wrap",
-            Mode::Panic => "panic",
-            Mode::Saturate => "saturate",
-            Mode::DontCare => "default"
+impl Parse for Overflower {
+     fn parse(input: ParseStream) -> Result<Self> {
+        let ident = input.parse::<Ident>()?;
+        if ident == "wrap" {
+            Ok(Overflower::Wrap)
+        } else if ident == "panic" {
+            Ok(Overflower::Panic)
+        } else if ident == "saturate" {
+            Ok(Overflower::Saturate)
+        } else if ident == "default" {
+            Ok(Overflower::Default)
+        } else {
+            panic!("Usage: overflow(wrap|panic|saturate|default)");
+        }
+    }
+}
+
+macro_rules! foldexpr {
+    ($s:expr, $ty:path, $t:ident, $f:path) => {
+        $ty(if is_overflow(& $t . attrs) {
+            $t
+        } else {
+            $f($s, $t)
         })
     }
 }
 
-fn get_trait_name(mode: Mode, method: &str) -> String {
-    let mo = match mode {
-            Mode::Wrap => "Wrap",
-            Mode::Panic => "Panic",
-            Mode::Saturate => "Saturate",
-            Mode::DontCare => "Default"
-    };
-    method.split("_").flat_map(|s| {
-        let mut me = s.chars();
-        me.next().unwrap().to_uppercase().chain(me)
-    }).chain(mo.chars()).collect()
+
+fn is_overflow(attrs: &[Attribute]) -> bool {
+    attrs.iter().any(|a| a.path.segments.iter()
+            .next().unwrap().ident == "overflow")
 }
 
-struct Overflower<'a, 'cx: 'a> {
-    mode: Mode,
-    cx: &'a mut ExtCtxt<'cx>,
-}
-
-fn is_stmt_macro(stmt: &Stmt) -> bool {
-    if let StmtKind::Mac(..) = stmt.node { true } else { false }
-}
-
-impl<'a, 'cx> Folder for Overflower<'a, 'cx> {
-    fn fold_item(&mut self, item: P<Item>) -> SmallVec<[P<Item>; 1]> {
-        if let ItemKind::Mac(_) = item.node {
-            let expanded = self.cx.expander().fold_item(item);
-            expanded.into_iter()
-                    .flat_map(|i| self.fold_item(i).into_iter())
-                    .collect()
-        } else {
-            fold::noop_fold_item(item, self)
-        }
-    }
-
-    fn fold_block(&mut self, block: P<Block>) -> P<Block> {
-        if block.stmts.iter().any(is_stmt_macro) {
-            let expanded = self.cx.expander().fold_block(block);
-            fold::noop_fold_block(expanded, self)
-        } else {
-            fold::noop_fold_block(block, self)
-        }
-    }
-
-    fn fold_expr(&mut self, expr: P<Expr>) -> P<Expr> {
-        { if self.mode == Mode::DontCare { return expr; } }
-        expr.map(|expr| match expr {
-            Expr { id, node: ExprKind::Call(path, args), span, attrs } => {
-                if args.len() == 1 {
-                    let pspan = path.span;
-                    if let ExprKind::Path(_, ref p) = path.node {
-                        if is_abs(p) {
-                            return tag_method(self, "abs", args, span, pspan);
-                        }
-                    }
-                }
-                fold::noop_fold_expr(Expr { id: id, node: ExprKind::Call(path, args),
-                        span: span, attrs: attrs }, self)
-            }
-            Expr { node: ExprKind::Binary( Spanned { node: BinOpKind::Add, span: op }, l, r), span, .. } => {
-                tag_method(self, "add", vec![l, r], span, op)
-            }
-            Expr { node: ExprKind::Binary( Spanned { node: BinOpKind::Sub, span: op }, l, r), span, .. } => {
-                tag_method(self, "sub", vec![l, r], span, op)
-            }
-            Expr { node: ExprKind::Binary( Spanned { node: BinOpKind::Mul, span: op }, l, r), span, .. } => {
-                tag_method(self, "mul", vec![l, r], span, op)
-            }
-            Expr { node: ExprKind::Binary( Spanned { node: BinOpKind::Div, span: op }, l, r), span, .. } => {
-                tag_method(self, "div", vec![l, r], span, op)
-            }
-            Expr { node: ExprKind::Binary( Spanned { node: BinOpKind::Rem, span: op }, l, r), span, .. } => {
-                tag_method(self, "rem", vec![l, r], span, op)
-            }
-            Expr { node: ExprKind::Binary( Spanned { node: BinOpKind::Shl, span: op }, l, r), span, .. } => {
-                tag_method(self, "shl", vec![l, r], span, op)
-            }
-            Expr { node: ExprKind::Binary( Spanned { node: BinOpKind::Shr, span: op }, l, r), span, .. } => {
-                tag_method(self, "shr", vec![l, r], span, op)
-            }
-            Expr { node: ExprKind::Unary(UnOp::Neg, arg), span, .. } => {
-                // yes, this span handling is ugly, but we don't have op spans on unary minus
-                tag_method(self, "neg", vec![arg], span, span)
-            }
-            Expr { node: ExprKind::AssignOp( Spanned { node: BinOpKind::Add, span: op }, l, r), span, .. } => {
-                let args = ref_mut(&mut self.cx, l, r);
-                tag_method(self, "add_assign", args, span, op)
-            }
-            Expr { node: ExprKind::AssignOp( Spanned { node: BinOpKind::Sub, span: op }, l, r), span, .. } => {
-                let args = ref_mut(&mut self.cx, l, r);
-                tag_method(self, "sub_assign", args, span, op)
-            }
-            Expr { node: ExprKind::AssignOp( Spanned { node: BinOpKind::Mul, span: op }, l, r), span, .. } => {
-                let args = ref_mut(&mut self.cx, l, r);
-                tag_method(self, "mul_assign", args, span, op)
-            }
-            Expr { node: ExprKind::AssignOp( Spanned { node: BinOpKind::Div, span: op }, l, r), span, .. } => {
-                let args = ref_mut(&mut self.cx, l, r);
-                tag_method(self, "div_assign", args, span, op)
-            }
-            Expr { node: ExprKind::AssignOp( Spanned { node: BinOpKind::Rem, span: op }, l, r), span, .. } => {
-                let args = ref_mut(&mut self.cx, l, r);
-                tag_method(self, "rem_assign", args, span, op)
-            }
-            Expr { node: ExprKind::AssignOp( Spanned { node: BinOpKind::Shl, span: op }, l, r), span, .. } => {
-                let args = ref_mut(&mut self.cx, l, r);
-                tag_method(self, "shl_assign", args, span, op)
-            }
-            Expr { node: ExprKind::AssignOp( Spanned { node: BinOpKind::Shr, span: op }, l, r), span, .. } => {
-                let args = ref_mut(&mut self.cx, l, r);
-                tag_method(self, "shr_assign", args, span, op)
-            }
-            e => fold::noop_fold_expr(e, self)
-        })
-    }
-
-    fn fold_mac(&mut self, mac: Mac) -> Mac {
-        mac
-    }
-}
-
-fn ref_mut(cx: &mut ExtCtxt, l: P<Expr>, r: P<Expr>) -> Vec<P<Expr>> {
-    vec![cx.expr_mut_addr_of(DUMMY_SP, l), r]
-}
-
-fn tag_method(o: &mut Overflower, name: &str, args: Vec<P<Expr>>, outer: Span, op: Span) -> Expr {
-    let crate_name = o.cx.ident_of("overflower_support");
-    let trait_name = o.cx.ident_of(&get_trait_name(o.mode, name));
-    let fn_name = o.cx.ident_of(&format!("{}_{}", name, o.mode));
-    let path = o.cx.path(op, vec![crate_name, trait_name, fn_name]);
-    let epath = o.cx.expr_path(path);
-    let args_expanded = o.fold_exprs(args);
-    o.cx.expr_call(outer, epath, args_expanded).into_inner()
-}
-
-fn is_abs(p: &Path) -> bool {
-    fn any_of(s: &PathSegment, options: &[&str]) -> bool {
-        let name : &str = &*s.ident.name.as_str();
-        options.iter().any(|o| o == &name)
-    }
-    let segs = &p.segments;
-    let len = segs.len();
-    len >= 2 && any_of(&segs[len - 2], &["i8", "i16", "i32", "i64", "isize"])
-            && any_of(&segs[len - 1], &["abs"])
-}
-
-fn parse_mode_str(w: &Symbol, span: Span)
-        -> Result<Mode, (Span, &'static str)> {
-    let w : &str = &*w.as_str();
-    if w == "wrap" {
-        Ok(Mode::Wrap)
-    } else if w == "panic" {
-        Ok(Mode::Panic)
-    } else if w == "saturate" {
-        Ok(Mode::Saturate)
-    } else if w == "default" {
-        Ok(Mode::DontCare)
-    } else {
-        Err((span, "Unknown overflow, expected wrap, panic or saturate"))
-    }
-}
-
-fn parse_mode_lit(lit: &Lit, span: Span) -> Result<Mode, (Span, &'static str)> {
-    if let LitKind::Str(ref i, _) = lit.node {
-        parse_mode_str(i, span)
-    } else {
-        return Err((span, "overflow argument must be a string literal"))
-    }
-}
-
-fn get_mode(mi: &MetaItem) -> Result<Mode, (Span, &'static str)> {
-    match mi.node {
-        MetaItemKind::NameValue(ref l) => {
-            assert!(mi.name() == "overflow");
-            parse_mode_lit(l, mi.span)
-        }
-        MetaItemKind::List(ref list) => {
-            assert!(mi.name() == "overflow");
-            if list.len() != 1 {
-                return Err((mi.span, "Expected exactly one argument to `#[overflow(_)]`"))
-            }
-            match list[0].node {
-                NestedMetaItemKind::Literal(ref l) => parse_mode_lit(l, mi.span),
-                NestedMetaItemKind::MetaItem(ref i) => {
-                    if let MetaItemKind::Word = i.node {
-                        parse_mode_str(&i.name(), mi.span)
-                    } else {
-                        Err((mi.span, "overflower does not do nested attributes"))
-                    }
-                }
-            }
-        }
-        _ => Err((mi.span, "Expected an argument to `#[overflow(_)]`"))
-    }
-}
-
-fn expect_one<T>(one: SmallVec<[T; 1]>) -> T {
-    if one.len() != 1 { panic!("Expected exactly one item"); }
-    one.into_iter().next().unwrap()
-}
-
-#[plugin_registrar]
-pub fn plugin_registrar(reg: &mut Registry) {
-    reg.register_syntax_extension(Symbol::intern("overflow"),
-        SyntaxExtension::MultiModifier(Box::new(|cx: &mut ExtCtxt, _span: Span, mi: &MetaItem,
-              a: Annotatable| {
-        let mode = get_mode(mi).unwrap_or_else(|(espan, e)| {
-            cx.span_err(espan, e);
-            Mode::DontCare
-        });
-        let o = &mut Overflower {
-            mode: mode,
-            cx: cx,
+impl Overflower {
+    fn method_path(&self, method: &str) -> syn::Path {
+        let mo = match *self {
+                Overflower::Wrap => "Wrap",
+                Overflower::Panic => "Panic",
+                Overflower::Saturate => "Saturate",
+                Overflower::Default => "Default"
         };
-        match a {
-            Annotatable::Item(i) => Annotatable::Item(expect_one(o.fold_item(i))),
-            Annotatable::TraitItem(i) => Annotatable::TraitItem(i.map(|i|
-                expect_one(o.fold_trait_item(i)))),
-            Annotatable::ImplItem(i) => Annotatable::ImplItem(i.map(|i|
-                expect_one(o.fold_impl_item(i)))),
-            Annotatable::Stmt(s) => Annotatable::Stmt(s.map(|s| expect_one(o.fold_stmt(s)))),
-            Annotatable::Expr(e) => Annotatable::Expr(o.fold_expr(e)),
-            a => a,
+        let crate_name = syn::parse_str::<Ident>("overflower_support").unwrap();
+        let trait_name = syn::parse_str::<Ident>(&(method.split("_").flat_map(|s| {
+            let mut me = s.chars();
+            me.next().unwrap().to_uppercase().chain(me)
+        }).collect::<String>() + mo)).unwrap();
+        let method_name = syn::parse_str::<Ident>(&format!("{}_{}",
+            method, &mo.to_lowercase())).unwrap();
+        parse_quote!(#crate_name :: #trait_name :: #method_name)
+    }
+
+    fn make_method(&self, m: &str, args: Vec<Expr>) -> Expr {
+        let method_path = Expr::Path(syn::ExprPath {
+            attrs: vec![],
+            qself: None,
+            path: self.method_path(m)
+        });
+        parse_quote!(#method_path ( #(#args),* ))
+    }
+
+    fn make_unary(&mut self, u: ExprUnary) -> Expr {
+        if let syn::UnOp::Neg(_) = u.op {
+            Expr::Unary(u)
+        } else if is_overflow(&u.attrs) {
+            Expr::Unary(u)
+        } else {
+            self.make_method("neg", vec![*u.expr])
         }
-    })));
+    }
+
+    fn make_assign_op(&mut self, a: ExprAssignOp) -> Expr {
+        if is_overflow(&a.attrs) {
+            return Expr::AssignOp(a);
+        }
+        let ExprAssignOp {
+            attrs,
+            left,
+            op,
+            right,
+        } = a;
+        let mut args = vec![Expr::Reference(ExprReference {
+                attrs: vec![],
+                and_token: Default::default(),
+                mutability: Some(Default::default()),
+                expr: Box::new(self.fold_expr(*left))
+            }), self.fold_expr(*right)];
+        match op {
+            syn::BinOp::AddEq(_) => self.make_method("add_assign", args),
+            syn::BinOp::SubEq(_) => self.make_method("sub_assign", args),
+            syn::BinOp::MulEq(_) => self.make_method("mul_assign", args),
+            syn::BinOp::DivEq(_) => self.make_method("div_assign", args),
+            syn::BinOp::RemEq(_) => self.make_method("rem_assign", args),
+            syn::BinOp::ShlEq(_) => self.make_method("shl_assign", args),
+            syn::BinOp::ShrEq(_) => self.make_method("shr_assign", args),
+            op => {
+                let (r, l) = (args.pop().unwrap(), args.pop().unwrap());
+                let e = if let Expr::Reference(ExprReference { expr, .. }) = l {
+                    expr
+                } else {
+                    unreachable!();
+                };
+                Expr::AssignOp(ExprAssignOp {
+                    attrs,
+                    left: e,
+                    op,
+                    right: Box::new(r),
+                })
+            }
+        }
+
+    }
+
+    fn make_binary(&mut self, b: ExprBinary) -> Expr {
+        if is_overflow(&b.attrs) {
+            return Expr::Binary(b);
+        }
+        let ExprBinary {
+            attrs,
+            left,
+            op,
+            right,
+        } = b;
+        let mut args = vec![self.fold_expr(*left), self.fold_expr(*right)];
+        match op {
+            syn::BinOp::Add(_) => self.make_method("add", args),
+            syn::BinOp::Sub(_) => self.make_method("sub", args),
+            syn::BinOp::Mul(_) => self.make_method("mul", args),
+            syn::BinOp::Div(_) => self.make_method("div", args),
+            syn::BinOp::Rem(_) => self.make_method("rem", args),
+            syn::BinOp::Shl(_) => self.make_method("shl", args),
+            syn::BinOp::Shr(_) => self.make_method("shr", args),
+            op => {
+                let (r, l) = (args.pop().unwrap(), args.pop().unwrap());
+                Expr::Binary(ExprBinary {
+                    attrs,
+                    left: Box::new(l),
+                    op,
+                    right: Box::new(r),
+                })
+            }
+        }
+    }
+}
+
+impl Fold for Overflower {
+    fn fold_impl_item_method(&mut self, i: ImplItemMethod) -> ImplItemMethod {
+        if is_overflow(&i.attrs) { return i; }
+        fold::fold_impl_item_method(self, i)
+    }
+
+    fn fold_item_fn(&mut self, i: ItemFn) -> ItemFn {
+        if is_overflow(&i.attrs) { return i; }
+        fold::fold_item_fn(self, i)
+    }
+
+    fn fold_item_impl(&mut self, i: ItemImpl) -> ItemImpl {
+        if is_overflow(&i.attrs) { return i; }
+        fold::fold_item_impl(self, i)
+    }
+
+    fn fold_item_mod(&mut self, i: ItemMod) -> ItemMod {
+        if is_overflow(&i.attrs) { return i; }
+        fold::fold_item_mod(self, i)
+    }
+
+    fn fold_item_trait(&mut self, i: ItemTrait) -> ItemTrait {
+        if is_overflow(&i.attrs) { return i; }
+        fold::fold_item_trait(self, i)
+    }
+
+    fn fold_trait_item_method(&mut self, i: TraitItemMethod) -> TraitItemMethod {
+        if is_overflow(&i.attrs) { return i; }
+        fold::fold_trait_item_method(self, i)
+    }
+
+
+    fn fold_expr(&mut self, e: Expr) -> Expr {
+        match e {
+            Expr::Box(b) => foldexpr!(self, Expr::Box, b, fold::fold_expr_box),
+            Expr::InPlace(i) => foldexpr!(self, Expr::InPlace, i, fold::fold_expr_in_place),
+            Expr::Array(a) => foldexpr!(self, Expr::Array, a, fold::fold_expr_array),
+            Expr::Call(c) => foldexpr!(self, Expr::Call, c, fold::fold_expr_call),
+            Expr::MethodCall(c) => foldexpr!(self, Expr::MethodCall, c, fold::fold_expr_method_call),
+            Expr::Tuple(t) => foldexpr!(self, Expr::Tuple, t, fold::fold_expr_tuple),
+            Expr::Binary(b) => self.make_binary(b),
+            Expr::Unary(u) => self.make_unary(u),
+            Expr::Cast(c) => foldexpr!(self, Expr::Cast, c, fold::fold_expr_cast),
+            Expr::Type(t) => foldexpr!(self, Expr::Type, t, fold::fold_expr_type),
+            Expr::Let(l) => foldexpr!(self, Expr::Let, l, fold::fold_expr_let),
+            Expr::If(i) => foldexpr!(self, Expr::If, i, fold::fold_expr_if),
+            Expr::While(w) => foldexpr!(self, Expr::While, w, fold::fold_expr_while),
+            Expr::ForLoop(f) => foldexpr!(self, Expr::ForLoop, f, fold::fold_expr_for_loop),
+            Expr::Loop(l) => foldexpr!(self, Expr::Loop, l, fold::fold_expr_loop),
+            Expr::Match(m) => foldexpr!(self, Expr::Match, m, fold::fold_expr_match),
+            Expr::Closure(c) => foldexpr!(self, Expr::Closure, c, fold::fold_expr_closure),
+            Expr::Unsafe(u) => foldexpr!(self, Expr::Unsafe, u, fold::fold_expr_unsafe),
+            Expr::Block(b) => foldexpr!(self, Expr::Block, b, fold::fold_expr_block),
+            Expr::Assign(a) => foldexpr!(self, Expr::Assign, a, fold::fold_expr_assign),
+            Expr::AssignOp(o) => self.make_assign_op(o),
+            Expr::Field(f) => foldexpr!(self, Expr::Field, f, fold::fold_expr_field),
+            Expr::Index(i) => foldexpr!(self, Expr::Index, i, fold::fold_expr_index),
+            Expr::Range(r) => foldexpr!(self, Expr::Range, r, fold::fold_expr_range),
+            Expr::Path(p) => foldexpr!(self, Expr::Path, p, fold::fold_expr_path),
+            Expr::Reference(r) => foldexpr!(self, Expr::Reference, r, fold::fold_expr_reference),
+            Expr::Break(b) => foldexpr!(self, Expr::Break, b, fold::fold_expr_break),
+            Expr::Return(r) => foldexpr!(self, Expr::Return, r, fold::fold_expr_return),
+            Expr::Macro(m) => foldexpr!(self, Expr::Macro, m, fold::fold_expr_macro),
+            Expr::Struct(s) => foldexpr!(self, Expr::Struct, s, fold::fold_expr_struct),
+            Expr::Repeat(r) => foldexpr!(self, Expr::Repeat, r, fold::fold_expr_repeat),
+            Expr::Paren(p) => foldexpr!(self, Expr::Paren, p, fold::fold_expr_paren),
+            Expr::Try(t) => foldexpr!(self, Expr::Try, t, fold::fold_expr_try),
+            Expr::Async(a) => foldexpr!(self, Expr::Async, a, fold::fold_expr_async),
+            Expr::TryBlock(t) => foldexpr!(self, Expr::TryBlock, t, fold::fold_expr_try_block),
+            Expr::Yield(y) => foldexpr!(self, Expr::Yield, y, fold::fold_expr_yield),
+            x => x,
+        }
+    }
+}
+
+#[proc_macro_attribute]
+pub fn overflow(attrs: TokenStream, code: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(code as Item);
+    let mut overflow = parse_macro_input!(attrs as Overflower);
+    let item = fold::fold_item(&mut overflow, input);
+    TokenStream::from(quote!(#item))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,29 +33,19 @@ impl Parse for Overflower {
     }
 }
 
-macro_rules! foldexpr {
-    ($s:expr, $ty:path, $t:ident, $f:path) => {
-        $ty(if is_overflow(& $t . attrs) {
-            $t
-        } else {
-            $f($s, $t)
-        })
-    }
-}
-
-
-fn is_overflow(attrs: &[Attribute]) -> bool {
-    attrs.iter().any(|a| a.path.segments.iter()
-            .next().unwrap().ident == "overflow")
-}
-
 impl Overflower {
+    fn is_overflow(&self, attrs: &[Attribute]) -> bool {
+        if let Overflower::Default = *self { return true; }
+        attrs.iter().any(|a| a.path.segments.iter()
+                .next().unwrap().ident == "overflow")
+    }
+
     fn method_path(&self, method: &str) -> syn::Path {
         let mo = match *self {
-                Overflower::Wrap => "Wrap",
-                Overflower::Panic => "Panic",
-                Overflower::Saturate => "Saturate",
-                Overflower::Default => "Default"
+            Overflower::Wrap => "Wrap",
+            Overflower::Panic => "Panic",
+            Overflower::Saturate => "Saturate",
+            Overflower::Default => "Default"
         };
         let crate_name = syn::parse_str::<Ident>("overflower_support").unwrap();
         let trait_name = syn::parse_str::<Ident>(&(method.split("_").flat_map(|s| {
@@ -79,7 +69,7 @@ impl Overflower {
     fn make_unary(&mut self, u: ExprUnary) -> Expr {
         if let syn::UnOp::Neg(_) = u.op {
             Expr::Unary(u)
-        } else if is_overflow(&u.attrs) {
+        } else if self.is_overflow(&u.attrs) {
             Expr::Unary(u)
         } else {
             self.make_method("neg", vec![*u.expr])
@@ -87,7 +77,7 @@ impl Overflower {
     }
 
     fn make_assign_op(&mut self, a: ExprAssignOp) -> Expr {
-        if is_overflow(&a.attrs) {
+        if self.is_overflow(&a.attrs) {
             return Expr::AssignOp(a);
         }
         let ExprAssignOp {
@@ -129,7 +119,7 @@ impl Overflower {
     }
 
     fn make_binary(&mut self, b: ExprBinary) -> Expr {
-        if is_overflow(&b.attrs) {
+        if self.is_overflow(&b.attrs) {
             return Expr::Binary(b);
         }
         let ExprBinary {
@@ -158,46 +148,88 @@ impl Overflower {
             }
         }
     }
+
+    fn make_call(&mut self, mut c: ExprCall) -> Expr {
+        if self.is_overflow(&c.attrs) {
+            return Expr::Call(c);
+        }
+        let is_abs = if let syn::Expr::Path(ref p) = *c.func {
+            let segments = &p.path.segments;
+            static FACADE : [&str; 2] = ["std", "core"];
+            static TYPES : [&str; 6] = ["i8", "i16", "i32", "i64", "i128",
+                "isize"];
+            static FUNCTION : [&str; 1] = ["abs"];
+            static ABS_MATCHERS : [&[&str]; 3] = [&FACADE, &TYPES, &FUNCTION];
+
+            if segments.iter().zip(&ABS_MATCHERS[3 - segments.len()..]).all(
+                |(seg, m)| seg.arguments.is_empty() && m.iter().any(
+                    |s| seg.ident == s)) {
+                true
+            } else {
+                false
+            }
+        } else {
+            false
+        };
+        if is_abs {
+            let func = match *self {
+                Overflower::Wrap => "::overflower_support::AbsWrap::abs_wrap",
+                Overflower::Panic => "::overflower_support::AbsPanic::abs_panic",
+                Overflower::Saturate => "::overflower_support::AbsSaturate::abs_saturate",
+                Overflower::Default => return Expr::Call(c),
+            };
+            c.func = Box::new(syn::parse_str::<Expr>(func).unwrap());
+        }
+        Expr::Call(c)
+    }
 }
 
 impl Fold for Overflower {
     fn fold_impl_item_method(&mut self, i: ImplItemMethod) -> ImplItemMethod {
-        if is_overflow(&i.attrs) { return i; }
+        if self.is_overflow(&i.attrs) { return i; }
         fold::fold_impl_item_method(self, i)
     }
 
     fn fold_item_fn(&mut self, i: ItemFn) -> ItemFn {
-        if is_overflow(&i.attrs) { return i; }
+        if self.is_overflow(&i.attrs) { return i; }
         fold::fold_item_fn(self, i)
     }
 
     fn fold_item_impl(&mut self, i: ItemImpl) -> ItemImpl {
-        if is_overflow(&i.attrs) { return i; }
+        if self.is_overflow(&i.attrs) { return i; }
         fold::fold_item_impl(self, i)
     }
 
     fn fold_item_mod(&mut self, i: ItemMod) -> ItemMod {
-        if is_overflow(&i.attrs) { return i; }
+        if self.is_overflow(&i.attrs) { return i; }
         fold::fold_item_mod(self, i)
     }
 
     fn fold_item_trait(&mut self, i: ItemTrait) -> ItemTrait {
-        if is_overflow(&i.attrs) { return i; }
+        if self.is_overflow(&i.attrs) { return i; }
         fold::fold_item_trait(self, i)
     }
 
     fn fold_trait_item_method(&mut self, i: TraitItemMethod) -> TraitItemMethod {
-        if is_overflow(&i.attrs) { return i; }
+        if self.is_overflow(&i.attrs) { return i; }
         fold::fold_trait_item_method(self, i)
     }
 
-
     fn fold_expr(&mut self, e: Expr) -> Expr {
+        macro_rules! foldexpr {
+            ($s:expr, $ty:path, $t:ident, $f:path) => {
+                $ty(if self.is_overflow(& $t . attrs) {
+                    $t
+                } else {
+                    $f($s, $t)
+                })
+            }
+        }
         match e {
             Expr::Box(b) => foldexpr!(self, Expr::Box, b, fold::fold_expr_box),
             Expr::InPlace(i) => foldexpr!(self, Expr::InPlace, i, fold::fold_expr_in_place),
             Expr::Array(a) => foldexpr!(self, Expr::Array, a, fold::fold_expr_array),
-            Expr::Call(c) => foldexpr!(self, Expr::Call, c, fold::fold_expr_call),
+            Expr::Call(c) => self.make_call(c),
             Expr::MethodCall(c) => foldexpr!(self, Expr::MethodCall, c, fold::fold_expr_method_call),
             Expr::Tuple(t) => foldexpr!(self, Expr::Tuple, t, fold::fold_expr_tuple),
             Expr::Binary(b) => self.make_binary(b),

--- a/tests/macro.rs
+++ b/tests/macro.rs
@@ -1,3 +1,4 @@
+#![feature(proc_macro_hygiene)]
 #![allow(const_err, unused)]
 
 #[macro_use] extern crate overflower;
@@ -8,12 +9,14 @@ macro_rules! id {
 }
 
 #[test]
+#[ignore]
 #[overflow(wrap)]
 fn test_macro_wrap() {
     id!(255u8 + 1);
 }
 
 #[test]
+#[ignore]
 #[should_panic]
 #[overflow(panic)]
 fn test_macro_panic() {

--- a/tests/macro.rs
+++ b/tests/macro.rs
@@ -1,6 +1,6 @@
-#![feature(plugin)]
-#![plugin(overflower)]
+#![allow(const_err, unused)]
 
+#[macro_use] extern crate overflower;
 extern crate overflower_support;
 
 macro_rules! id {

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -1,6 +1,4 @@
-#![feature(plugin)]
-#![plugin(overflower)]
-
+#[macro_use] extern crate overflower;
 extern crate overflower_support;
 
 #[test]


### PR DESCRIPTION
This removes the old macro_registrar interface and does the macro using `syn` and `quote`.

Currently macros don't get expanded. This is a shortcoming of the new API, not something we can fix for now.