### PR TITLE
Remove travis cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ addons:
   apt:
     packages:
       - gcc-multilib
-cache: cargo
 sudo: false
 script: |
   curl -sSL https://raw.githubusercontent.com/carllerche/travis-rust-matrix/master/test | bash


### PR DESCRIPTION
The lastest travis build failed because thte cache has grown so large that there's no chance it would get unpacked in 10 minutes.

Quite frankly, your project is small and hardly needs any cache at all, just remove it.